### PR TITLE
Fix colored names & more

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-    implementation 'com.google.code.gson:gson:2.8.6'
+    // modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 processResources {

--- a/src/main/java/com/kevin/tiertagger/TierTagger.java
+++ b/src/main/java/com/kevin/tiertagger/TierTagger.java
@@ -1,6 +1,7 @@
 package com.kevin.tiertagger;
 
 import net.fabricmc.api.ModInitializer;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
@@ -13,13 +14,12 @@ public class TierTagger implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        System.out.println("Hello World!");
         tiers.tiersLoader();
     }
 
-    public static Text appendTier(Text text) {
+    public static Text appendTier(PlayerEntity player, Text text) {
 
-        MutableText tier = getPlayerTier(text.getString());
+        MutableText tier = getPlayerTier(player.getEntityName());
         if (tier != null) {
             tier.append(Text.literal(" | ").styled(s -> s.withColor(Formatting.GRAY)));
             return tier.append(text);

--- a/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
@@ -16,8 +16,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 
 @Mixin(PlayerEntityRenderer.class)
-public abstract class NametagMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
-    protected NametagMixin(EntityRendererFactory.Context ctx, PlayerEntityModel<AbstractClientPlayerEntity> model, float shadowRadius) {
+public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
+    protected PlayerEntityRendererMixin(EntityRendererFactory.Context ctx, PlayerEntityModel<AbstractClientPlayerEntity> model, float shadowRadius) {
         super(ctx, model, shadowRadius);
     }
 

--- a/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
@@ -2,18 +2,16 @@ package com.kevin.tiertagger.mixin;
 
 import com.kevin.tiertagger.TierTagger;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.client.render.entity.model.PlayerEntityModel;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 
 @Mixin(PlayerEntityRenderer.class)
@@ -22,15 +20,18 @@ public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<Abs
         super(ctx, model, shadowRadius);
     }
 
-    @Redirect(
+    @ModifyArgs(
             // This specifies method
             method = "renderLabelIfPresent(Lnet/minecraft/client/network/AbstractClientPlayerEntity;Lnet/minecraft/text/Text;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
             // This Specifies where
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/LivingEntityRenderer;renderLabelIfPresent(Lnet/minecraft/entity/Entity;Lnet/minecraft/text/Text;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1)
     )
-    public void nametagReplace(LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> instance, Entity entity, Text text, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
+    public void nametagReplace(Args args) {
+        PlayerEntity entity = args.get(0);
+        Text text = args.get(1);
+
         // Sorta like a tunnel: text -> appendTier(text) -> text <tier> -> super.renderLabelIfPresent(text) -> completed!
-        text = TierTagger.appendTier((PlayerEntity) entity, text);
-        super.renderLabelIfPresent((AbstractClientPlayerEntity) entity, text, matrixStack, vertexConsumerProvider, i);
+        text = TierTagger.appendTier(entity, text);
+        args.set(1, text);
     }
 }

--- a/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/PlayerEntityRendererMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.client.render.entity.model.PlayerEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,7 +30,7 @@ public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<Abs
     )
     public void nametagReplace(LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> instance, Entity entity, Text text, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
         // Sorta like a tunnel: text -> appendTier(text) -> text <tier> -> super.renderLabelIfPresent(text) -> completed!
-        text = TierTagger.appendTier(text);
+        text = TierTagger.appendTier((PlayerEntity) entity, text);
         super.renderLabelIfPresent((AbstractClientPlayerEntity) entity, text, matrixStack, vertexConsumerProvider, i);
     }
 }

--- a/src/main/resources/TierTagger.mixins.json
+++ b/src/main/resources/TierTagger.mixins.json
@@ -6,7 +6,7 @@
   "mixins": [
   ],
   "client": [
-    "NametagMixin"
+    "PlayerEntityRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.13",
-    "fabric": "*",
     "minecraft": "1.19.2"
   }
 }


### PR DESCRIPTION
This PR fixes a few things:
* tiers not being displayed when the player has a colored/formatted name
* fixes potential conflicts with other mods because of `@Redirect`
* removes unneeded dependencies