### PR TITLE
Add spanish translations

### DIFF
--- a/src/main/resources/assets/tier-tagger/lang/es_es.json
+++ b/src/main/resources/assets/tier-tagger/lang/es_es.json
@@ -1,0 +1,16 @@
+{
+  "tiertagger.config.enabled": "Habilitado",
+  "tiertagger.config.gamemode": "Modo de juego",
+  "tiertagger.config.unranked": "Mostrar sin clasificar",
+  "tiertagger.config.retired": "Mostrar retirado",
+  "tiertagger.config.statistic": "Estadística mostrada",
+  "tiertagger.clear": "Borrar Tier Caché",
+  "tiertagger.stat.tier": "Tier",
+  "tiertagger.stat.rank": "Rango",
+  "tiertagger.outdated.title": "§c§lVersión desactualizada de TierTagger detectado !!!",
+  "tiertagger.outdated.desc": "Se ha encontrado una nueva versión: %s!\nEs §naltamente recomendable§r actualizar para mantener el mod de trabajo!",
+  "tiertagger.outdated.download": "§aDescargar la nueva versión",
+  "tiertagger.outdated.ignore": "§4Ignorar (no se recomienda) ",
+  "tiertagger.obsolete.title": "§c§lObsolote Minecraft versión detectada !!!",
+  "tiertagger.obsolete.desc": "Estás jugando en una §nversión de Minecraft no soportada.§r\nEsta versión es probable que esté roto, y usted debe considerar la actualización de su Minecraft tan pronto como sea posible."
+}


### PR DESCRIPTION
Add spanish translations because a great deal of players (especially in gamemodes like UHC) are spanish. I have added spanish translations in this commit though. I did not translate `"tiertagger.stat.tier"` because I feel like more people use the tier instead of the spanish translation. This is the same for `"tiertagger.clear"` which I translated it except the word tier. 
If you have any issues or doubts please feel free to leave a comment **:]**