### PR TITLE
Append peak tiers to the output of the tiertagger command

### DIFF
--- a/src/main/java/com/kevin/tiertagger/TierTagger.java
+++ b/src/main/java/com/kevin/tiertagger/TierTagger.java
@@ -15,6 +15,7 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.VersionParsingException;
 import net.minecraft.SharedConstants;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -89,7 +90,7 @@ public class TierTagger implements ModInitializer {
         MutableText following = switch (manager.getConfig().getShownStatistic()) {
             case TIER -> getPlayerTier(player.getUuid())
                     .map(entry -> {
-                        String tier = getTierText(entry.ranking());
+                        String tier = getTierString(entry.ranking());
                         MutableText tierText = Text.literal(tier).withColor(getTierColor(tier));
 
                         if (manager.getConfig().isShowIcons() && entry.mode() != null && entry.mode().icon().isPresent()) {
@@ -138,12 +139,31 @@ public class TierTagger implements ModInitializer {
     }
 
     @NotNull
-    public static String getTierText(PlayerInfo.Ranking ranking) {
+    public static String getTierString(PlayerInfo.Ranking ranking) {
         if (manager.getConfig().isShowRetired() && ranking.retired() && ranking.peakTier() != null && ranking.peakPos() != null) {
             return "R" + (ranking.peakPos() == 0 ? "H" : "L") + "T" + ranking.peakTier();
         } else {
             return (ranking.pos() == 0 ? "H" : "L") + "T" + ranking.tier();
         }
+    }
+
+    public static Text getTierText(int tier, int pos, boolean retired) {
+        StringBuilder text = new StringBuilder();
+        if (retired) text.append("R");
+        text.append(pos == 0 ? "H" : "L").append("T").append(tier);
+
+        int color = TierTagger.getTierColor(text.toString());
+        return Text.literal(text.toString()).styled(s -> s.withColor(color));
+    }
+
+    public static Text appendPeakTier(PlayerInfo.Ranking tier, Text tierText) {
+        if (tier.comparablePeak() >= tier.comparableTier()) return tierText;
+
+        // warning caused by potential NPE by unboxing of peak{Tier,Pos} which CANNOT happen, see impl of comparablePeak
+        // noinspection DataFlowIssue
+       return tierText.copy().append(Text.literal(" (peak: ").styled(s -> s.withColor(Formatting.GRAY)))
+                .append(getTierText(tier.peakTier(), tier.peakPos(), tier.retired()))
+                .append(Text.literal(")").styled(s -> s.withColor(Formatting.GRAY)));
     }
 
     private static int displayTierInfo(CommandContext<FabricClientCommandSource> ctx) {
@@ -160,7 +180,7 @@ public class TierTagger implements ModInitializer {
         } else {
             ctx.getSource().sendFeedback(Text.of("[TierTagger] Searching..."));
             TierCache.searchPlayer(selector.name())
-                    .thenAccept(p -> ctx.getSource().sendFeedback(printPlayerInfo(p)))
+                    .thenAccept(p -> MinecraftClient.getInstance().execute(() -> ctx.getSource().sendFeedback(printPlayerInfo(p))))
                     .exceptionally(t -> {
                         ctx.getSource().sendError(Text.of("Could not find player " + selector.name()));
                         return null;
@@ -179,9 +199,10 @@ public class TierTagger implements ModInitializer {
             info.rankings().forEach((m, r) -> {
                 if (m == null) return;
                 GameMode mode = TierCache.findModeOrUgly(m);
-                String tier = getTierText(r);
+                String tier = getTierString(r);
 
                 Text tierText = Text.literal(tier).styled(s -> s.withColor(getTierColor(tier)));
+                tierText = appendPeakTier(r, tierText);
                 text.append(Text.literal("\n").append(mode.asStyled(true)).append(": ").append(tierText));
             });
 

--- a/src/main/java/com/kevin/tiertagger/tierlist/PlayerInfoScreen.java
+++ b/src/main/java/com/kevin/tiertagger/tierlist/PlayerInfoScreen.java
@@ -11,7 +11,6 @@ import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.PlayerSkinWidget;
 import net.minecraft.client.gui.widget.TextWidget;
 import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.uku3lig.ukulib.config.screen.CloseableScreen;
@@ -77,29 +76,13 @@ public class PlayerInfoScreen extends CloseableScreen {
     }
 
     private Text formatTier(@NotNull GameMode gamemode, PlayerInfo.Ranking tier) {
-        MutableText tierText = getTierText(tier.tier(), tier.pos(), tier.retired());
-
-        if (tier.comparablePeak() < tier.comparableTier()) {
-            // warning caused by potential NPE by unboxing of peak{Tier,Pos} which CANNOT happen, see impl of comparablePeak
-            // noinspection DataFlowIssue
-            tierText = tierText.append(Text.literal(" (peak: ").styled(s -> s.withColor(Formatting.GRAY)))
-                    .append(getTierText(tier.peakTier(), tier.peakPos(), tier.retired()))
-                    .append(Text.literal(")").styled(s -> s.withColor(Formatting.GRAY)));
-        }
+        Text tierText = TierTagger.getTierText(tier.tier(), tier.pos(), tier.retired());
+        tierText = TierTagger.appendPeakTier(tier, tierText);
 
         return Text.empty()
                 .append(gamemode.asStyled(true))
                 .append(Text.literal(": ").formatted(Formatting.GRAY))
                 .append(tierText);
-    }
-
-    private MutableText getTierText(int tier, int pos, boolean retired) {
-        StringBuilder text = new StringBuilder();
-        if (retired) text.append("R");
-        text.append(pos == 0 ? "H" : "L").append("T").append(tier);
-
-        int color = TierTagger.getTierColor(text.toString());
-        return Text.literal(text.toString()).styled(s -> s.withColor(color));
     }
 
     private Text getRegionText(PlayerInfo info) {
@@ -131,7 +114,7 @@ public class PlayerInfoScreen extends CloseableScreen {
     }
 
     private int points(PlayerInfo.Ranking ranking) {
-        String tier = getTierText(ranking.tier(), ranking.pos(), false).getString();
+        String tier = TierTagger.getTierText(ranking.tier(), ranking.pos(), false).getString();
 
         return switch (tier) {
             case "HT1" -> 60;


### PR DESCRIPTION
I made it so that peak tiers are appended to the output of the tiertagger command.
<img width="329" height="177" alt="2025-10-05-005958_hyprshot" src="https://github.com/user-attachments/assets/50ca9c51-ce72-4a54-b922-fb225a42f9ae" />
I moved moved the code from the PlayerInfoScreen that appends the peak tier to the TierTagger class. And made both the PlayerInfoScreen and tiertagger command use it.

https://github.com/TheVoidBlock/TierTagger/blob/098ed019d838d340089e5d62777accdb58faaba7/src/main/java/com/kevin/tiertagger/TierTagger.java#L254
https://github.com/TheVoidBlock/TierTagger/blob/098ed019d838d340089e5d62777accdb58faaba7/src/main/java/com/kevin/tiertagger/TierTagger.java#L188

I also moved ```getTierText(int tier, int pos, boolean retired)``` from PlayerInfoScreen into the TierTagger class and made public and static.

https://github.com/TheVoidBlock/TierTagger/blob/098ed019d838d340089e5d62777accdb58faaba7/src/main/java/com/kevin/tiertagger/TierTagger.java#L245

I then made sure it runs on the render thread by wrapping ```ctx.getSource().sendFeedback(printPlayerInfo(p))``` with `MinecraftClient.getInstance().execute()`.

https://github.com/TheVoidBlock/TierTagger/blob/098ed019d838d340089e5d62777accdb58faaba7/src/main/java/com/kevin/tiertagger/TierTagger.java#L164

Not sure why the links aren't giving a code preview.