### PR TITLE
Show tiers in player list

### DIFF
--- a/src/main/java/com/kevin/tiertagger/TierTagger.java
+++ b/src/main/java/com/kevin/tiertagger/TierTagger.java
@@ -18,7 +18,6 @@ import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -86,8 +85,8 @@ public class TierTagger implements ModInitializer {
         checkForUpdates();
     }
 
-    public static Text appendTier(PlayerEntity player, Text text) {
-        MutableText following = getPlayerTier(player.getUuid())
+    public static Text appendTier(UUID uuid, Text text) {
+        MutableText following = getPlayerTier(uuid)
                 .map(entry -> {
                     Text tierText = getRankingText(entry.ranking(), false);
 

--- a/src/main/java/com/kevin/tiertagger/config/TTConfigScreen.java
+++ b/src/main/java/com/kevin/tiertagger/config/TTConfigScreen.java
@@ -41,6 +41,7 @@ public class TTConfigScreen extends TabbedConfigScreen<TierTaggerConfig> {
                     CyclingOption.ofBoolean("tiertagger.config.retired", config.isShowRetired(), config::setShowRetired),
                     CyclingOption.ofTranslatableEnum("tiertagger.config.highest", TierTaggerConfig.HighestMode.class, config.getHighestMode(), config::setHighestMode, SimpleOption.constantTooltip(Text.translatable("tiertagger.config.highest.desc"))),
                     CyclingOption.ofBoolean("tiertagger.config.icons", config.isShowIcons(), config::setShowIcons),
+                    CyclingOption.ofBoolean("tiertagger.config.playerList", config.isPlayerList(), config::setPlayerList),
                     new SimpleButton("tiertagger.clear", b -> TierCache.clearCache()),
                     new ScreenOpenButton("tiertagger.config.search", PlayerSearchScreen::new)
             };

--- a/src/main/java/com/kevin/tiertagger/config/TierTaggerConfig.java
+++ b/src/main/java/com/kevin/tiertagger/config/TierTaggerConfig.java
@@ -22,6 +22,7 @@ public class TierTaggerConfig implements Serializable {
     private boolean showRetired = true;
     private HighestMode highestMode = HighestMode.NOT_FOUND;
     private boolean showIcons = true;
+    private boolean playerList = true;
     private int retiredColor = 0xa2d6ff;
     // note: this is a GSON internal class. this *might* break in the future
     private LinkedTreeMap<String, Integer> tierColors = defaultColors();

--- a/src/main/java/com/kevin/tiertagger/mixin/MixinPlayerEntity.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/MixinPlayerEntity.java
@@ -13,7 +13,7 @@ public class MixinPlayerEntity {
     public Text prependTier(Text original) {
         if (TierTagger.getManager().getConfig().isEnabled()) {
             PlayerEntity self = (PlayerEntity) (Object) this;
-            return TierTagger.appendTier(self, original);
+            return TierTagger.appendTier(self.getUuid(), original);
         } else {
             return original;
         }

--- a/src/main/java/com/kevin/tiertagger/mixin/MixinPlayerListHud.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/MixinPlayerListHud.java
@@ -1,0 +1,25 @@
+package com.kevin.tiertagger.mixin;
+
+import com.kevin.tiertagger.TierTagger;
+import com.kevin.tiertagger.config.TierTaggerConfig;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.minecraft.client.gui.hud.PlayerListHud;
+import net.minecraft.client.network.PlayerListEntry;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(PlayerListHud.class)
+public class MixinPlayerListHud {
+    @ModifyReturnValue(method = "getPlayerName", at = @At("RETURN"))
+    @Nullable
+    public Text prependTier(Text original, PlayerListEntry entry) {
+        TierTaggerConfig config = TierTagger.getManager().getConfig();
+        if (config.isEnabled() && config.isPlayerList()) {
+            return TierTagger.appendTier(entry.getProfile().id(), original);
+        } else {
+            return original;
+        }
+    }
+}

--- a/src/main/java/com/kevin/tiertagger/mixin/MixinTextDisplayEntityRenderer.java
+++ b/src/main/java/com/kevin/tiertagger/mixin/MixinTextDisplayEntityRenderer.java
@@ -24,7 +24,7 @@ public class MixinTextDisplayEntityRenderer {
             for (PlayerEntity player : world.getPlayers()) {
                 int index = stringText.indexOf(player.getNameForScoreboard());
                 if (!isSurrounded(stringText, index, player.getNameForScoreboard().length())) {
-                    return TierTagger.appendTier(player, text);
+                    return TierTagger.appendTier(player.getUuid(), text);
                 }
             }
         }

--- a/src/main/resources/TierTagger.mixins.json
+++ b/src/main/resources/TierTagger.mixins.json
@@ -7,6 +7,7 @@
     "MixinPlayerEntity"
   ],
   "client": [
+    "MixinPlayerListHud",
     "MixinTextDisplayEntityRenderer",
     "MixinTitleScreen"
   ],

--- a/src/main/resources/assets/tier-tagger/lang/en_us.json
+++ b/src/main/resources/assets/tier-tagger/lang/en_us.json
@@ -10,6 +10,7 @@
   "tiertagger.config.highest.desc": "- Never: only display tiers in the selected gamemode\n- When Not Found: if a person isn't ranked in the current selected gamemode, show their highest tier overall\n- Always: display a person's highest tier, regardless of the gamemode",
   "tiertagger.config.search": "Search Player",
   "tiertagger.config.icons": "Show Gamemode Icons",
+  "tiertagger.config.playerList": "Show Tiers in Player List",
   "tiertagger.colors": "Tier Colors",
   "tiertagger.colors.retired": "Retired",
   "tiertagger.search": "Search",


### PR DESCRIPTION
I made it so that tiers show up in the player list and added a config option. I also changed the `appendTier` method to take in a `GameProfile` instead of a `PlayerEntity` so that it's more flexible.

<img width="885" height="212" alt="Config Option" src="https://github.com/user-attachments/assets/ffab6d96-2b13-4cf2-bf1d-90c4b334eebd" />
<img width="565" height="545" alt="Player List" src="https://github.com/user-attachments/assets/2bde565a-35f7-4cec-8458-54cac040832d" />
